### PR TITLE
[Bugfix] Handle Situation Where No Password Given

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@ build
 dist
 *.egg-info
 *.egg_info
+
+# Emacs
+\#*\#
+*~

--- a/send_nsca/nsca.py
+++ b/send_nsca/nsca.py
@@ -98,10 +98,19 @@ class XORCrypter(Crypter):
     def encrypt(self, value):
         value_s = map(ord, list(value))
         repeated_iv = map(ord, list(int(math.ceil(float(len(value)) / len(self.iv))) * self.iv))
-        repeated_password = map(ord, list(int(math.ceil(float(len(value)) / len(self.password))) * self.password))
+
+        repeated_password = (
+            map(ord, list(int(math.ceil(float(len(value)) / len(self.password))) * self.password))
+            if self.password
+            else None
+        )
         xorer = functools.partial(apply, int.__xor__)
         xor1 = map(xorer, zip(value_s, repeated_iv))
-        xor2 = map(xorer, zip(xor1, repeated_password))
+        xor2 = (
+            map(xorer, zip(xor1, repeated_password))
+            if repeated_password
+            else xor1
+        )
         return ''.join(map(chr, xor2))
 
 

--- a/tests/unit/test_crypters.py
+++ b/tests/unit/test_crypters.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+import random
+import unittest
+
+from send_nsca import nsca
+
+
+class TestXORCrypter(unittest.TestCase):
+
+    def test_should_handle_case_where_no_password_is_given(self):
+        crypter = nsca.XORCrypter('123', '', random.randint)
+        result = crypter.encrypt('Test')
+        self.assertEqual(result, 'eW@E')


### PR DESCRIPTION
* Presently, if no password is given, the XORCrypter produces a
  DivideByZero error. This patch adds correct handling for this
  situation as well as a unit-test to verify that it works. This has
  already been tested in production.